### PR TITLE
Fix broken social share meta tags (og:image, og:type, twitter:url)

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,7 +11,7 @@
     <meta property="og:title" content="{% if title %}{{ title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
     <meta property="og:description" content="{% if excerpt %}{{ excerpt }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
     <meta property="og:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}" />
-    <meta property="og:image" content="{{ site.url }}{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}{{ site.cover }}{% endif %}" />
+    <meta property="og:image" content="{% if page.cover %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.url }}{{ site.baseurl }}{{ page.cover }}{% endif %}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.cover }}{% endif %}" />
     <meta property="article:publisher" content="https://www.facebook.com/{{ site.facebook }}" />{% if excerpt %}
     <meta property="article:author" content="https://www.facebook.com/{{ site.facebook }}" />
     <meta property="article:published_time" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% elsif post.date %}{{ post.date | date_to_xmlschema }}{% endif %}" />
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="{% if title %}{{ title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
     <meta name="twitter:description" content="{% if excerpt %}{{ excerpt }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
     <meta name="twitter:url" content="{{ site.url }}{{ site.baseurl }}" />
-    <meta name="twitter:image" content="{{ site.url }}{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}{{ site.cover }}{% endif %}" />
+    <meta name="twitter:image" content="{% if page.cover %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.url }}{{ site.baseurl }}{{ page.cover }}{% endif %}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.cover }}{% endif %}" />
     <meta name="twitter:label1" content="Written by" />
     <meta name="twitter:data1" content="{{ site.title }}" />{% if page.tags.size > 0 %}
     <meta name="twitter:label2" content="Filed under" />
@@ -50,7 +50,7 @@
     "url": "{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}",
     "image": {
         "@type": "ImageObject",
-        "url": "{{ site.url }}{{ site.baseurl }}{% if page.cover %}{{ page.cover }}{% else %}{{ site.cover }}{% endif %}",
+        "url": "{% if page.cover %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.url }}{{ site.baseurl }}{{ page.cover }}{% endif %}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.cover }}{% endif %}",
         "width": 2000,
         "height": 666
     },

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,20 +7,20 @@
         {% assign excerpt = page.content | strip_html | truncatewords: 50, "" %}
      {% endif %} <!--title below is coming from _includes/dynamic_title-->
     <meta property="og:site_name" content="{{ site.title }}" />
-    <meta property="og:type" content="website" />
+    <meta property="og:type" content="{% if excerpt %}article{% else %}website{% endif %}" />
     <meta property="og:title" content="{% if title %}{{ title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
     <meta property="og:description" content="{% if excerpt %}{{ excerpt }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
     <meta property="og:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}" />
     <meta property="og:image" content="{% if page.cover %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.url }}{{ site.baseurl }}{{ page.cover }}{% endif %}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.cover }}{% endif %}" />
-    <meta property="article:publisher" content="https://www.facebook.com/{{ site.facebook }}" />{% if excerpt %}
-    <meta property="article:author" content="https://www.facebook.com/{{ site.facebook }}" />
+    {% if site.facebook %}<meta property="article:publisher" content="https://www.facebook.com/{{ site.facebook }}" />{% endif %}{% if excerpt %}{% if site.facebook %}
+    <meta property="article:author" content="https://www.facebook.com/{{ site.facebook }}" />{% endif %}
     <meta property="article:published_time" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% elsif post.date %}{{ post.date | date_to_xmlschema }}{% endif %}" />
     <meta property="article:modified_time" content="{% if page.date %}{{ page.date | date_to_xmlschema }}{% elsif post.date %}{{ post.date | date_to_xmlschema }}{% endif %}" />{% endif %}{% if page.tags.size > 0 %}
     <meta property="article:tag" content="{{ page.tags | first | capitalizeall }}" />{% endif %}
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{% if title %}{{ title }}{% elsif page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}" />
     <meta name="twitter:description" content="{% if excerpt %}{{ excerpt }}{% elsif page.description %}{{ page.description }}{% else %}{{ site.description }}{% endif %}" />
-    <meta name="twitter:url" content="{{ site.url }}{{ site.baseurl }}" />
+    <meta name="twitter:url" content="{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}" />
     <meta name="twitter:image" content="{% if page.cover %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.url }}{{ site.baseurl }}{{ page.cover }}{% endif %}{% else %}{{ site.url }}{{ site.baseurl }}{{ site.cover }}{% endif %}" />
     <meta name="twitter:label1" content="Written by" />
     <meta name="twitter:data1" content="{{ site.title }}" />{% if page.tags.size > 0 %}


### PR DESCRIPTION
## Summary
- Fix `og:image`/`twitter:image` producing an invalid doubled-domain URL when `page.cover` is already an absolute URL (all recent posts published via the ia.net/writer micropub flow set `cover` this way), which is why social previews were missing images
- `og:type` now reflects `article` on post pages vs `website` elsewhere, instead of always `website` alongside `article:*` tags
- `article:publisher`/`article:author` no longer emit the broken `https://www.facebook.com/false` (from the unset `site.facebook: False` config value)
- `twitter:url` now matches the current page instead of always pointing at the homepage

## Test plan
- [x] Built the site locally with Jekyll and confirmed `og:image`/`twitter:image` render as valid single-domain URLs for both a post with an absolute `cover` and pages falling back to the relative site-wide cover
- [x] Confirmed `og:type` renders `article` on post pages and `website` on the homepage
- [x] Confirmed `article:publisher`/`article:author` are omitted (no `site.facebook` configured) instead of emitting a broken URL
- [x] Confirmed `twitter:url` matches the current page's canonical URL on both a post page and the homepage


---
_Generated by [Claude Code](https://claude.ai/code/session_01S3xVQWVeHpDDc9CmgZXUFJ)_