### PR TITLE
Fix missing slash in production URLs by not overriding Jekyll baseurl

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -43,8 +43,13 @@ jobs:
         id: pages
         uses: actions/configure-pages@v5
       - name: Build with Jekyll
-        # Outputs to the './_site' directory by default
-        run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+        # Outputs to the './_site' directory by default.
+        # Not passing --baseurl: this site serves from a custom domain root
+        # (see CNAME), so _config.yml's baseurl: "/" must be left as-is.
+        # actions/configure-pages resolves base_path to "" for a custom
+        # domain, which would override it and break every {{ site.url }}
+        # {{ site.baseurl }}... concatenation in the templates.
+        run: bundle exec jekyll build
         env:
           JEKYLL_ENV: production
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- Follow-up to #48. After that PR merged, `og:url` on the live site still rendered wrong — `https://www.colinframe.coman-experiment-in-intentionality-two-years-in` (missing slash between domain and path)
- Root cause: `.github/workflows/jekyll.yml`'s build step runs `jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"`. For a custom domain (this repo's `CNAME` points at `www.colinframe.com`), `actions/configure-pages` resolves `base_path` to an **empty string**, since Pages serves from the domain root rather than a `/reponame/` subpath. That empty string silently overrode `_config.yml`'s `baseurl: "/"` in every production build — breaking every tag built as `{{ site.url }}{{ site.baseurl }}...` (canonical, `og:url`, `twitter:url`, JSON-LD `url`/`@id`, favicon, logo)
- `og:image`/`twitter:image` were unaffected by this because #48 made them skip the `site.baseurl` concatenation entirely when `page.cover` is already an absolute URL
- Fix: drop the `--baseurl` override from the workflow so the site's own `baseurl: "/"` config (already correct for a custom domain) is respected
- Second bug found once the domain-root deploy was tested against the actual post pages: the "read next" post-card partials (`post-card-previous.html`, `post-card-next.html`) and the author/tag archive header backgrounds still unconditionally prepended `site.baseurl` to `cover`, producing malformed URLs like `url(/https://www.colinframe.com/images/posts/...)` for any post whose cover is already absolute (all current posts, published via the ia.net/writer micropub flow). Applied the same absolute-URL check used in `head.html` (#48) everywhere `cover` gets concatenated with `site.baseurl`.

## Test plan
- [x] Built locally with `jekyll build --baseurl ""` (reproducing the production flag) and confirmed `canonical`/`og:url`/`twitter:url` render with the domain and path glued together, matching the reported bug
- [x] Built locally without the `--baseurl` override (matching this fix) and confirmed `canonical`, `og:url`, `twitter:url`, and `og:image` all render as valid, correctly-slashed URLs
- [x] Built with `--drafts` and confirmed the "read next" card on `an-experiment-in-intentionality-two-years-in` now renders a clean cover image URL instead of `/https://www.colinframe.com/...`
