### PR TITLE
Fix remaining glued-URL bugs in cover images and share links

### DIFF
--- a/_includes/floating-header.html
+++ b/_includes/floating-header.html
@@ -11,11 +11,11 @@
     <div class="floating-header-title">{{ page.title }}</div>
     <div class="floating-header-share">
         <div class="floating-header-share-label">Share this {% include point.html %}</div>
-        <a class="floating-header-share-tw" href="https://twitter.com/share?text={{ page.title | url_encode }}&amp;url={{ site.production_url }}{{ page.url | remove_first: '/' }}"
+        <a class="floating-header-share-tw" href="https://twitter.com/share?text={{ page.title | url_encode }}&amp;url={{ site.production_url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}"
             onclick="window.open(this.href, 'share-twitter', 'width=550,height=235');return false;">
             {% include twitter.html %}
         </a>
-        <a class="floating-header-share-fb" href="https://www.facebook.com/sharer/sharer.php?u={{ site.production_url }}{{ page.url | remove_first: '/' }}"
+        <a class="floating-header-share-fb" href="https://www.facebook.com/sharer/sharer.php?u={{ site.production_url }}{% if site.baseurl %}{{ site.baseurl }}{% endif %}{{ page.url | remove_first: '/' }}"
             onclick="window.open(this.href, 'share-facebook','width=580,height=296');return false;">
             {% include facebook.html %}
         </a>

--- a/_includes/post-card-next.html
+++ b/_includes/post-card-next.html
@@ -3,7 +3,7 @@
     <article class="post-card {{ page.next.class }}{% unless page.next.cover %} no-image{% endunless %}">
         {% if page.next.cover %}
             <a class="post-card-image-link" href="{{ site.baseurl }}{{ page.next.url | remove_first: '/' }}">
-                <div class="post-card-image" style="background-image: url({{ site.baseurl }}{{ page.next.cover }})"></div>
+                <div class="post-card-image" style="background-image: url({% if page.next.cover contains '://' %}{{ page.next.cover }}{% else %}{{ site.baseurl }}{{ page.next.cover }}{% endif %})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">

--- a/_includes/post-card-previous.html
+++ b/_includes/post-card-previous.html
@@ -3,7 +3,7 @@
     <article class="post-card {{ page.previous.class }}{% unless page.previous.cover %} no-image{% endunless %}">
         {% if page.previous.cover %}
             <a class="post-card-image-link" href="{{ site.baseurl }}{{ page.previous.url | remove_first: '/' }}">
-                <div class="post-card-image" style="background-image: url({{ site.baseurl }}{{ page.previous.cover }})"></div>
+                <div class="post-card-image" style="background-image: url({% if page.previous.cover contains '://' %}{{ page.previous.cover }}{% else %}{{ site.baseurl }}{{ page.previous.cover }}{% endif %})"></div>
             </a>
         {% endif %}
         <div class="post-card-content">

--- a/_layouts/author.html
+++ b/_layouts/author.html
@@ -15,7 +15,7 @@ logo: 'assets/images/ghost.png'
 <!-- Everything inside the #author tags pulls data from the author -->
 {% for author in site.data.authors %}
     {% if author[1].username == page.author %}
-    <header class="site-header outer {% if author[1].cover or page.cover %}" style="background-image: url({{ site.baseurl }}{% if author[1].cover %}{{ author[1].cover }}{% elsif page.cover %}{{ page.cover }}{% endif %}) {% else %}no-cover{% endif %}">
+    <header class="site-header outer {% if author[1].cover or page.cover %}" style="background-image: url({% if author[1].cover %}{{ site.baseurl }}{{ author[1].cover }}{% elsif page.cover %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.baseurl }}{{ page.cover }}{% endif %}{% endif %}) {% else %}no-cover{% endif %}">
         <div class="inner">
             {% include site-nav.html %}
             <div class="site-header-content">

--- a/_layouts/tag.html
+++ b/_layouts/tag.html
@@ -14,7 +14,7 @@ logo: 'assets/images/ghost.png'
 <!-- The big featured header, it uses blog cover image as a BG if available -->
 <!-- #tag -->
 {% include dynamic_tag_info.html %}
-<header class="site-header outer {% if cover or page.cover %}" style="background-image: url({{ site.baseurl }}{% if cover %}{{ cover }}{% else %}{{ page.cover }}{% endif%}) {% else %}no-cover{% endif %}">
+<header class="site-header outer {% if cover or page.cover %}" style="background-image: url({% if cover %}{{ site.baseurl }}{{ cover }}{% else %}{% if page.cover contains '://' %}{{ page.cover }}{% else %}{{ site.baseurl }}{{ page.cover }}{% endif %}{% endif%}) {% else %}no-cover{% endif %}">
     <div class="inner">
         {% include site-nav.html %}
         <div class="site-header-content">


### PR DESCRIPTION
## Summary
Follow-up to #48/#49. Same root cause each time: templates that concatenate `site.baseurl`/`site.production_url` directly with a `cover` or `page.url` value, written assuming that value is always relative — but real posts (published via the ia.net/writer micropub flow) set `cover` as a full absolute URL, and `site.baseurl` was, until #49, being silently emptied out in production. Two more instances of the pattern surfaced:

- **`_includes/post-card-previous.html` / `post-card-next.html`** (the "read next" card at the bottom of a post) and **`_layouts/author.html` / `tag.html`** (archive header backgrounds): unconditionally prepended `site.baseurl` to `cover`, producing `url(/https://www.colinframe.com/images/posts/...)` for any post whose cover is absolute. Applied the same "skip the prefix if already absolute" check used in `head.html` (#48).
- **`_includes/floating-header.html`**: built the Twitter/Facebook share links as `{{ site.production_url }}{{ page.url | remove_first: '/' }}` with no `site.baseurl` (or any separator) in between at all, producing `https://www.colinframe.comai-as-a-reflection-of-human-nature`. Added `site.baseurl` into the concatenation.

Found by grepping every page of a full production-equivalent build for two signatures: a slash immediately followed by a nested absolute URL, and a domain glued directly to a path with no separating slash. Both signatures are now clean across the whole built site.

## Test plan
- [x] Full local build (matching production, no `--baseurl` override); grepped all `.html`/`.xml` output for `/https?://` glue and `colinframe.com<word>` glue — zero matches after these fixes (both patterns had multiple hits per post beforehand)
- [x] Spot-checked the read-next card and the floating-header share links on `ai-as-a-reflection-of-human-nature.html` render clean, correctly-slashed URLs


---
_Generated by [Claude Code](https://claude.ai/code/session_01S3xVQWVeHpDDc9CmgZXUFJ)_